### PR TITLE
Fix facebook workflow

### DIFF
--- a/.github/workflows/facebook-poemadeldia.yml
+++ b/.github/workflows/facebook-poemadeldia.yml
@@ -27,4 +27,8 @@ jobs:
           DL_PASSWD: ${{secrets.DB_DL_PASSWD}}
         run: curl -u "${DL_USER}:${DL_PASSWD}" --output poems.db ${DL_URL}
       - name: Post the poem to facebook
-        run: npx tsx src/post-poem.ts poems.db "${secrets.FB_LONG_LIVED_PAGE_ACCESS_TOKEN}000"
+        env:
+          FB_PAGE_ID: ${{ vars.FB_PAGE_ID }}
+          FB_API_VERSION: ${{ vars.FB_API_VERSION }}
+          FB_LONG_LIVED_PAGE_ACCESS_TOKEN: ${{ secrets.FB_LONG_LIVED_PAGE_ACCESS_TOKEN }}
+        run: npx tsx src/post-poem.ts poems.db "${FB_LONG_LIVED_PAGE_ACCESS_TOKEN}"

--- a/facebook/src/post-poem.ts
+++ b/facebook/src/post-poem.ts
@@ -1,11 +1,21 @@
 import "reflect-metadata";
 import { parseArgs } from "node:util";
 import { bootstrapPostPoemUseCase } from "./bootstrap";
+import { GenericError } from "./domain/errors";
 
 async function main() {
   const commandLineArguments = getCommandLineArguments();
   const postPoemUseCase = await bootstrapPostPoemUseCase(commandLineArguments);
-  await postPoemUseCase.execute();
+  try {
+    await postPoemUseCase.execute();
+  } catch (error: unknown) {
+    if (error instanceof GenericError) {
+      console.error("%o: %o", error.message, error.detail);
+    } else {
+      console.error("%o", error);
+    }
+    process.exit(1);
+  }
 }
 
 function getCommandLineArguments(): {

--- a/facebook/src/use-cases/PostPoemUseCase.ts
+++ b/facebook/src/use-cases/PostPoemUseCase.ts
@@ -17,17 +17,9 @@ export class PostPoemUseCase {
     const renderedPoem = await this.renderPoemUseCase.execute(randomPoem);
     console.log("rendered poem %o", renderedPoem);
 
-    try {
-      await this.facebookPostMessageToPageUseCase.execute(
-        process.env.FB_PAGE_ID!,
-        renderedPoem,
-      );
-    } catch (error: unknown) {
-      if (error instanceof GenericError) {
-        console.error("%o: %o", error.message, error.detail);
-      } else {
-        console.error("%o", error);
-      }
-    }
+    await this.facebookPostMessageToPageUseCase.execute(
+      process.env.FB_PAGE_ID!,
+      renderedPoem,
+    );
   }
 }


### PR DESCRIPTION
* Pass environment variables and secrets in the facebook workflow.
* Make the post-poem script exit with status code non-zero if an error occurs.